### PR TITLE
GH-1914: fix tailwind css missing export field

### DIFF
--- a/packages/tailwindcss-config/package.json
+++ b/packages/tailwindcss-config/package.json
@@ -29,6 +29,8 @@
     "themes/with-spacing.js"
   ],
   "license": "MIT",
+  "main": "tailwind.config.js",
+  "module": "tailwind.config.js",
   "name": "@busybox/tailwindcss-config",
   "peerDependencies": {
     "tailwindcss": ">=3"


### PR DESCRIPTION
this fix #1914